### PR TITLE
50 questionanswer   frontend v2

### DIFF
--- a/backend/src/controllers/answer/answer.controller.ts
+++ b/backend/src/controllers/answer/answer.controller.ts
@@ -1,9 +1,11 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
 } from '@nestjs/common';
 import { AnswerDto } from 'src/dtos/answer.dto';
@@ -14,7 +16,7 @@ import {
 } from 'src/mappers/answer.mapper';
 import { AnswerService } from 'src/services/answer/answer.service';
 
-@Controller('answers')
+@Controller('answer')
 export class AnswerController {
   constructor(private readonly _answerService: AnswerService) {}
 
@@ -34,5 +36,19 @@ export class AnswerController {
   async getById(@Param('id', ParseIntPipe) id: number): Promise<AnswerDto> {
     const entity = await this._answerService.getById(id);
     return answerEntityToAnswerDto(entity);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: Partial<AnswerCreateDto>,
+  ): Promise<AnswerDto> {
+    const entity = await this._answerService.update(id, dto);
+    return answerEntityToListingDto(entity);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this._answerService.delete(id);
   }
 }

--- a/backend/src/dtos/answer.form.dto.ts
+++ b/backend/src/dtos/answer.form.dto.ts
@@ -1,6 +1,8 @@
-import { IsString } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 
 export class AnswerCreateDto {
   @IsString()
   answer: string;
+  @IsNumber()
+  question_id: number;
 }

--- a/backend/src/dtos/question.form.dto.ts
+++ b/backend/src/dtos/question.form.dto.ts
@@ -1,9 +1,15 @@
-import { IsString, MinLength } from 'class-validator';
+import { IsNumber, IsString, MinLength } from 'class-validator';
 
 export class QuestionCreateDto {
   @IsString()
   @MinLength(10)
   question: string;
+
+  @IsNumber()
+  theme_id: number;
+
+  @IsNumber()
+  correct_answer_id: number;
 }
 
 export class QuestionUpdateDto {

--- a/backend/src/services/answer/answer.service.ts
+++ b/backend/src/services/answer/answer.service.ts
@@ -34,4 +34,15 @@ export class AnswerService {
       relations: ['question'],
     });
   }
+
+  async update(id: number, data: Partial<AnswerEntity>): Promise<AnswerEntity> {
+    const answer = await this.getById(id);
+    Object.assign(answer, data);
+    return await this._answerRepo.save(answer);
+  }
+
+  async delete(id: number): Promise<void> {
+    const answer = await this.getById(id);
+    await this._answerRepo.remove(answer);
+  }
 }

--- a/backend/src/services/question/question.service.ts
+++ b/backend/src/services/question/question.service.ts
@@ -12,7 +12,11 @@ export class QuestionService {
   ) {}
 
   async create(dto: QuestionCreateDto): Promise<QuestionEntity> {
-    const question = this._questionRepo.create(dto);
+    const question = this._questionRepo.create({
+      question: dto.question,
+      theme: { id: dto.theme_id },
+      correct_answer: { id: dto.correct_answer_id },
+    });
     return await this._questionRepo.save(question);
   }
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -22,6 +22,11 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'question',
+    loadComponent: () =>
+      import('./features/question/pages/question-page/question-page').then((m) => m.QuestionPage),
+  },
+  {
     path: 'dashboard',
     loadComponent: () =>
       import('./features/dashboard/dashboard-page/dashboard-page').then((m) => m.DashboardPage),

--- a/frontend/src/app/components/nav-bar/nav-bar.html
+++ b/frontend/src/app/components/nav-bar/nav-bar.html
@@ -2,8 +2,7 @@
   <ul>
     <li><a routerLink="/match/create">New Quizz</a></li>
     <li><a routerLink="/quizz">Quizz</a></li>
-
-    <li><a routerLink="/question">Quizz</a></li>
+    <li><a routerLink="/question"> Add Question</a></li>
 
     @if (isConnected()) {
       <li><a routerLink="/member/me">Profil</a></li>

--- a/frontend/src/app/components/nav-bar/nav-bar.html
+++ b/frontend/src/app/components/nav-bar/nav-bar.html
@@ -3,6 +3,8 @@
     <li><a routerLink="/match/create">New Quizz</a></li>
     <li><a routerLink="/quizz">Quizz</a></li>
 
+    <li><a routerLink="/question">Quizz</a></li>
+
     @if (isConnected()) {
       <li><a routerLink="/member/me">Profil</a></li>
       @if (isAdmin()) {

--- a/frontend/src/app/core/services/answer.service.ts
+++ b/frontend/src/app/core/services/answer.service.ts
@@ -33,4 +33,11 @@ export class AnswerService {
     );
     return response.data;
   }
+
+  async create(answer: string): Promise<Answer> {
+    const response = await firstValueFrom(
+      this._httpClient.post<{ data: Answer }>(this._apiUrl + '/answer', { answer }),
+    );
+    return response.data;
+  }
 }

--- a/frontend/src/app/core/services/question.service.ts
+++ b/frontend/src/app/core/services/question.service.ts
@@ -30,4 +30,15 @@ export class QuestionService {
     );
     return response.data;
   }
+
+  async create(data: {
+    question: string;
+    theme_id: number;
+    correct_answer_id: number;
+  }): Promise<QuestionData> {
+    const response = await firstValueFrom(
+      this._htttpClient.post<{ data: QuestionData }>(this._apiUrl + '/question', data),
+    );
+    return response.data;
+  }
 }

--- a/frontend/src/app/core/services/question.service.ts
+++ b/frontend/src/app/core/services/question.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable, signal } from '@angular/core';
-import { UserRole } from '../enums/user-role.enum';
-import { Question, QuestionData } from '../models/question.interface';
+import { inject, Injectable } from '@angular/core';
+import { QuestionData } from '../models/question.interface';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
@@ -9,24 +8,19 @@ import { environment } from '../../../environments/environment';
   providedIn: 'root',
 })
 export class QuestionService {
-  private readonly _htttpClient = inject(HttpClient);
+  private readonly _httpClient = inject(HttpClient);
   private readonly _apiUrl = environment.apiUrl;
-
-  private _authToken = signal<string>('');
-  authToken = this._authToken.asReadonly();
-  private _role = signal<UserRole | null>(null);
-  role = this._role.asReadonly();
 
   async getQuestionById(id: number): Promise<QuestionData> {
     const response = await firstValueFrom(
-      this._htttpClient.get<{ data: QuestionData }>(this._apiUrl + '/question/' + id),
+      this._httpClient.get<{ data: QuestionData }>(this._apiUrl + '/question/' + id),
     );
     return response.data;
   }
 
   async getAll(): Promise<Array<QuestionData>> {
     const response = await firstValueFrom(
-      this._htttpClient.get<{ data: Array<QuestionData> }>(this._apiUrl + '/question'),
+      this._httpClient.get<{ data: Array<QuestionData> }>(this._apiUrl + '/question'),
     );
     return response.data;
   }
@@ -37,7 +31,7 @@ export class QuestionService {
     correct_answer_id: number;
   }): Promise<QuestionData> {
     const response = await firstValueFrom(
-      this._htttpClient.post<{ data: QuestionData }>(this._apiUrl + '/question', data),
+      this._httpClient.post<{ data: QuestionData }>(this._apiUrl + '/question', data),
     );
     return response.data;
   }

--- a/frontend/src/app/features/dashboard/dashboard-page/dashboard-page.css
+++ b/frontend/src/app/features/dashboard/dashboard-page/dashboard-page.css
@@ -1,0 +1,1 @@
+h1 {font-family: Arial, Helvetica, sans-serif;}

--- a/frontend/src/app/features/dashboard/dashboard-page/dashboard-page.html
+++ b/frontend/src/app/features/dashboard/dashboard-page/dashboard-page.html
@@ -1,1 +1,1 @@
-<p>dashboard-page works!</p>
+<h1>Dashboard</h1>

--- a/frontend/src/app/features/question/pages/question-page/question-page.css
+++ b/frontend/src/app/features/question/pages/question-page/question-page.css
@@ -1,0 +1,33 @@
+form {
+    max-width: 700px;
+    outline: solid;
+    border-radius: 5px;
+    outline-width: 1px;
+    outline-color: rgb(211, 211, 211);
+    padding: 20px;
+    margin: 20px;
+    color: rgb(130, 130, 130);
+    background-color: rgb(248, 248, 248);
+}
+
+div {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 10px 0px;
+}
+
+label {
+    width: 100px;
+}
+
+input {
+    border: none;
+    border-radius: 5px;
+    background-color: rgb(236, 236, 236);
+}
+
+.buttonSubmit {
+    margin-top: 50px;
+    display: flex;
+    justify-content: flex-start;
+}

--- a/frontend/src/app/features/question/pages/question-page/question-page.html
+++ b/frontend/src/app/features/question/pages/question-page/question-page.html
@@ -12,9 +12,10 @@
   </div>
   <div>
     <label for="answer-input">Answer :</label>
-    <input type="text" id="answer-input" formControlName="answer" />
+    <input type="text" id="answer-input" formControlName="correct_answer_id" />
     <app-forms-error-display [control]="correct_answer_id" name="answer" />
   </div>
+  <button type="submit" [disabled]="formQuestion.invalid">Add Question</button>
 </form>
 
 <table>

--- a/frontend/src/app/features/question/pages/question-page/question-page.html
+++ b/frontend/src/app/features/question/pages/question-page/question-page.html
@@ -1,9 +1,8 @@
-<p>question-page works!</p>
 <form [formGroup]="formQuestion" (ngSubmit)="onSubmitNewQuestion()">
   <div>
-    <label for="theme-input">Theme :</label>
-    <input type="text" id="theme-input" formControlName="theme" />
-    <app-forms-error-display [control]="theme" name="theme" />
+    <label for="theme-input">Theme ID :</label>
+    <input type="number" id="theme-input" formControlName="theme_id" />
+    <app-forms-error-display [control]="theme_id" name="theme_id" />
   </div>
   <div>
     <label for="question-input">Question :</label>
@@ -11,19 +10,19 @@
     <app-forms-error-display [control]="question" name="question" />
   </div>
   <div>
-    <label for="answer-input">Answer :</label>
-    <input type="text" id="answer-input" formControlName="correct_answer_id" />
-    <app-forms-error-display [control]="correct_answer_id" name="answer" />
+    <label for="answer-input">Correct Answer ID :</label>
+    <input type="number" id="answer-input" formControlName="correct_answer_id" />
+    <app-forms-error-display [control]="correct_answer_id" name="correct_answer_id" />
   </div>
   <button type="submit" [disabled]="formQuestion.invalid">Add Question</button>
 </form>
 
 <table>
   <thead>
-    <th>id</th>
-    <th>theme</th>
-    <th>question</th>
-    <th>answer</th>
+  <th>id</th>
+  <th>theme</th>
+  <th>question</th>
+  <th>answer</th>
   </thead>
   <tbody>
     @for (question of questions(); track question.id) {

--- a/frontend/src/app/features/question/pages/question-page/question-page.ts
+++ b/frontend/src/app/features/question/pages/question-page/question-page.ts
@@ -1,10 +1,8 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
 import { QuestionService } from '../../../../core/services/question.service';
 import { AuthService } from '../../../../core/services/auth.service';
-import { Question, QuestionData } from '../../../../core/models/question.interface';
-import { Theme } from '../../../../core/models/theme.interface';
+import { QuestionData } from '../../../../core/models/question.interface';
 import { FormsErrorDisplay } from '../../../../components/forms-error-display/forms-error-display';
 
 @Component({
@@ -15,14 +13,11 @@ import { FormsErrorDisplay } from '../../../../components/forms-error-display/fo
 })
 export class QuestionPage {
   private readonly _fb = inject(FormBuilder);
-  private readonly _router = inject(Router);
   private readonly _questionService = inject(QuestionService);
-
-  private readonly _route = inject(ActivatedRoute);
   private readonly _authService = inject(AuthService);
+
   isAdmin = this._authService.isAdmin;
   isConnected = this._authService.isConnected;
-
   questions = signal<Array<QuestionData>>([]);
 
   async ngOnInit(): Promise<void> {
@@ -30,32 +25,25 @@ export class QuestionPage {
     this.questions.set(data);
   }
 
-  //=============================================================
-
-  id = new FormControl<number>(1, [Validators.required]);
-  theme = new FormControl<Theme | null>(null, [Validators.required]);
+  theme_id = new FormControl<number | null>(null, [Validators.required]);
   question = new FormControl<string>('', [Validators.required]);
-  correct_answer_id = new FormControl<number>(1, [Validators.required]);
+  correct_answer_id = new FormControl<number | null>(null, [Validators.required]);
 
-  //==============================================================
   formQuestion = this._fb.group({
-    id: this.id,
-    theme: this.theme,
+    theme_id: this.theme_id,
     question: this.question,
     correct_answer_id: this.correct_answer_id,
   });
-  //==============================================================
 
-  onSubmitNewQuestion() {
+  async onSubmitNewQuestion() {
     if (this.formQuestion.valid) {
-      console.log(this.formQuestion.value);
-
-      const data: QuestionData = {
-        id: this.formQuestion.value.id!,
-        theme: this.formQuestion.value.theme!,
+      const created = await this._questionService.create({
         question: this.formQuestion.value.question!,
+        theme_id: this.formQuestion.value.theme_id!,
         correct_answer_id: this.formQuestion.value.correct_answer_id!,
-      };
+      });
+      this.questions.update(q => [...q, created]);
+      this.formQuestion.reset();
     }
   }
 }

--- a/frontend/src/app/features/question/question.router.ts
+++ b/frontend/src/app/features/question/question.router.ts
@@ -1,7 +1,7 @@
 import { Routes } from '@angular/router';
 export const routes: Routes = [
   {
-    path: '/question',
+    path: 'question',
     loadComponent: () => import('./pages/question-page/question-page').then((c) => c.QuestionPage),
   },
 ];


### PR DESCRIPTION
  Backend :                                                                                         
  - Correction de la route du contrôleur Answer : /answers → /answer                                
  - Ajout de question_id dans AnswerCreateDto pour lier une réponse à une question                  
  - Ajout de theme_id et correct_answer_id dans QuestionCreateDto
  - Correction du QuestionService pour lier les relations theme et correct_answer via TypeORM
  - Ajout des méthodes update() et delete() dans AnswerService
  - Ajout des endpoints PATCH et DELETE dans AnswerController

  Frontend :
  - Correction du typo _htttpClient → _httpClient dans QuestionService
  - Suppression des signaux inutiles copiés depuis AuthService
  - Correction du formulaire question : theme → theme_id
  - Le formulaire soumet maintenant les données au service (appel manquant)