### PR TITLE
feat: admin dashboard/ users, quizz, themes , questions management

### DIFF
--- a/frontend/src/app/core/services/question.service.ts
+++ b/frontend/src/app/core/services/question.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { QuestionData } from '../models/question.interface';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { QuestionData } from '../models/question.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -11,28 +11,28 @@ export class QuestionService {
   private readonly _httpClient = inject(HttpClient);
   private readonly _apiUrl = environment.apiUrl;
 
-  async getQuestionById(id: number): Promise<QuestionData> {
+  async getAll(): Promise<QuestionData[]> {
+    const response = await firstValueFrom(
+      this._httpClient.get<{ data: QuestionData[] }>(this._apiUrl + '/question'),
+    );
+    return response.data;
+  }
+
+  async getById(id: number): Promise<QuestionData> {
     const response = await firstValueFrom(
       this._httpClient.get<{ data: QuestionData }>(this._apiUrl + '/question/' + id),
     );
     return response.data;
   }
 
-  async getAll(): Promise<Array<QuestionData>> {
-    const response = await firstValueFrom(
-      this._httpClient.get<{ data: Array<QuestionData> }>(this._apiUrl + '/question'),
-    );
-    return response.data;
-  }
-
-  async create(data: {
-    question: string;
-    theme_id: number;
-    correct_answer_id: number;
-  }): Promise<QuestionData> {
+  async create(data: { question: string; theme_id: number; correct_answer_id: number }): Promise<QuestionData> {
     const response = await firstValueFrom(
       this._httpClient.post<{ data: QuestionData }>(this._apiUrl + '/question', data),
     );
     return response.data;
+  }
+
+  async delete(id: number): Promise<void> {
+    await firstValueFrom(this._httpClient.delete(this._apiUrl + '/question/' + id));
   }
 }

--- a/frontend/src/app/core/services/quizz.service.ts
+++ b/frontend/src/app/core/services/quizz.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QuizzService {
+  private readonly _httpClient = inject(HttpClient);
+  private readonly _apiUrl = environment.apiUrl;
+
+  async getAll(): Promise<any[]> {
+    const response = await firstValueFrom(
+      this._httpClient.get<{ data: any[] }>(this._apiUrl + '/quizz'),
+    );
+    return response.data;
+  }
+
+  async delete(id: number): Promise<void> {
+    await firstValueFrom(this._httpClient.delete(this._apiUrl + '/quizz/' + id));
+  }
+}

--- a/frontend/src/app/core/services/theme.service.ts
+++ b/frontend/src/app/core/services/theme.service.ts
@@ -1,0 +1,24 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Theme } from '../models/theme.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThemeService {
+  private readonly _httpClient = inject(HttpClient);
+  private readonly _apiUrl = environment.apiUrl;
+
+  async getAll(): Promise<Theme[]> {
+    const response = await firstValueFrom(
+      this._httpClient.get<{ data: Theme[] }>(this._apiUrl + '/theme'),
+    );
+    return response.data;
+  }
+
+  async delete(id: number): Promise<void> {
+    await firstValueFrom(this._httpClient.delete(this._apiUrl + '/theme/' + id));
+  }
+}

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { User } from '../models/user.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  private readonly _httpClient = inject(HttpClient);
+  private readonly _apiUrl = environment.apiUrl;
+
+  async getAll(): Promise<User[]> {
+    const response = await firstValueFrom(
+      this._httpClient.get<{ data: User[] }>(this._apiUrl + '/user'),
+    );
+    return response.data;
+  }
+
+  async delete(id: number): Promise<void> {
+    await firstValueFrom(this._httpClient.delete(this._apiUrl + '/user/' + id));
+  }
+}
+

--- a/frontend/src/app/features/admin/admin-page/admin-page.css
+++ b/frontend/src/app/features/admin/admin-page/admin-page.css
@@ -1,0 +1,89 @@
+:host {
+  display: block;
+  padding: 2rem;
+  font-family: sans-serif;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  color: #1a1a2e;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid #e0e0e0;
+  padding-bottom: 0.5rem;
+}
+
+.tabs button {
+  padding: 0.5rem 1.2rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #555;
+  border-radius: 6px 6px 0 0;
+  transition: background 0.2s, color 0.2s;
+}
+
+.tabs button:hover {
+  background: #f0f0f0;
+  color: #1a1a2e;
+}
+
+.tabs button.active {
+  background: #1a1a2e;
+  color: white;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+thead {
+  background: #1a1a2e;
+  color: white;
+}
+
+th {
+  padding: 0.8rem 1rem;
+  text-align: left;
+  font-weight: 600;
+}
+
+td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f0f0f0;
+  color: #333;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+tr:hover td {
+  background: #f9f9f9;
+}
+
+.btn-delete {
+  padding: 0.3rem 0.8rem;
+  background: #e53935;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s;
+}
+
+.btn-delete:hover {
+  background: #b71c1c;
+}

--- a/frontend/src/app/features/admin/admin-page/admin-page.html
+++ b/frontend/src/app/features/admin/admin-page/admin-page.html
@@ -1,1 +1,108 @@
-<p>admin-page works!</p>
+<div>
+  <h1>Dashboard Admin</h1>
+
+  <div class="tabs">
+    <button [class.active]="activeTab() === 'users'" (click)="activeTab.set('users')">Utilisateurs</button>
+    <button [class.active]="activeTab() === 'quizz'" (click)="activeTab.set('quizz')">Quiz</button>
+    <button [class.active]="activeTab() === 'themes'" (click)="activeTab.set('themes')">Thèmes</button>
+    <button [class.active]="activeTab() === 'questions'" (click)="activeTab.set('questions')">Questions</button>
+  </div>
+
+  @if (activeTab() === 'users') {
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Username</th>
+          <th>Email</th>
+          <th>Rôle</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (user of users(); track user.id) {
+          <tr>
+            <td>{{ user.id }}</td>
+            <td>{{ user.username }}</td>
+            <td>{{ user.email }}</td>
+            <td>{{ user.role }}</td>
+            <td>
+              <button class="btn-delete" (click)="deleteUser(user.id)">Supprimer</button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+
+  @if (activeTab() === 'quizz') {
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Titre</th>
+          <th>Visibilité</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (quizz of quizzes(); track quizz.id) {
+          <tr>
+            <td>{{ quizz.id }}</td>
+            <td>{{ quizz.title }}</td>
+            <td>{{ quizz.visibility }}</td>
+            <td>
+              <button class="btn-delete" (click)="deleteQuizz(quizz.id)">Supprimer</button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+
+  @if (activeTab() === 'themes') {
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nom</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (theme of themes(); track theme.id) {
+          <tr>
+            <td>{{ theme.id }}</td>
+            <td>{{ theme.name }}</td>
+            <td>
+              <button class="btn-delete" (click)="deleteTheme(theme.id)">Supprimer</button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+
+  @if (activeTab() === 'questions') {
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Question</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (question of questions(); track question.id) {
+          <tr>
+            <td>{{ question.id }}</td>
+            <td>{{ question.question }}</td>
+            <td>
+              <button class="btn-delete" (click)="deleteQuestion(question.id)">Supprimer</button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+</div>

--- a/frontend/src/app/features/admin/admin-page/admin-page.ts
+++ b/frontend/src/app/features/admin/admin-page/admin-page.ts
@@ -1,9 +1,79 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { UserService } from '../../../core/services/user.service';
+import { QuizzService } from '../../../core/services/quizz.service';
+import { ThemeService } from '../../../core/services/theme.service';
+import { QuestionService } from '../../../core/services/question.service';
+import { User } from '../../../core/models/user.interface';
+import { Theme } from '../../../core/models/theme.interface';
+import { QuestionData } from '../../../core/models/question.interface';
 
 @Component({
   selector: 'app-admin-page',
   imports: [],
   templateUrl: './admin-page.html',
   styleUrl: './admin-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AdminPage {}
+export class AdminPage implements OnInit {
+  private readonly _userService = inject(UserService);
+  private readonly _quizzService = inject(QuizzService);
+  private readonly _themeService = inject(ThemeService);
+  private readonly _questionService = inject(QuestionService);
+
+  protected activeTab = signal<'users' | 'quizz' | 'themes' | 'questions'>('users');
+  protected users = signal<User[]>([]);
+  protected quizzes = signal<any[]>([]);
+  protected themes = signal<Theme[]>([]);
+  protected questions = signal<QuestionData[]>([]);
+
+  async ngOnInit(): Promise<void> {
+    await this.loadAll();
+  }
+
+  private async loadAll(): Promise<void> {
+    try {
+      this.users.set(await this._userService.getAll());
+      this.quizzes.set(await this._quizzService.getAll());
+      this.themes.set(await this._themeService.getAll());
+      this.questions.set(await this._questionService.getAll());
+    } catch {
+      console.error('Erreur lors du chargement des données');
+    }
+  }
+
+  async deleteUser(id: number): Promise<void> {
+    try {
+      await this._userService.delete(id);
+      this.users.update((list) => list.filter((u) => u.id !== id));
+    } catch {
+      console.error('Erreur lors de la suppression');
+    }
+  }
+
+  async deleteQuizz(id: number): Promise<void> {
+    try {
+      await this._quizzService.delete(id);
+      this.quizzes.update((list) => list.filter((q) => q.id !== id));
+    } catch {
+      console.error('Erreur lors de la suppression');
+    }
+  }
+
+  async deleteTheme(id: number): Promise<void> {
+    try {
+      await this._themeService.delete(id);
+      this.themes.update((list) => list.filter((t) => t.id !== id));
+    } catch {
+      console.error('Erreur lors de la suppression');
+    }
+  }
+
+  async deleteQuestion(id: number): Promise<void> {
+    try {
+      await this._questionService.delete(id);
+      this.questions.update((list) => list.filter((q) => q.id !== id));
+    } catch {
+      console.error('Erreur lors de la suppression');
+    }
+  }
+}


### PR DESCRIPTION
 Ajout du dashboard admin Angular :                                                              
                                                                                                  
  - Création des services manquants : UserService, QuizzService, ThemeService                     
  - Ajout de la méthode delete() dans QuestionService                                             
  - Dashboard admin avec 4 onglets : Utilisateurs, Quiz, Thèmes, Questions                        
  - Chaque onglet affiche une liste avec un bouton Supprimer
  - Onglet actif mis en évidence visuellement
  - CSS pour un rendu propre (tableau, onglets, bouton rouge)
